### PR TITLE
Update composer/installers version - issue/#1284

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,6 @@
 		}
 	],
 	"require": {
-		"composer/installers": "~1.3.0"
+		"composer/installers": "~1.0"
 	}
 }


### PR DESCRIPTION
Current version is incompatible with Bedrock.  New version works without
compatibility errors during installation